### PR TITLE
Changed e-file module and removed the multiple calls to pfl

### DIFF
--- a/command-not-found
+++ b/command-not-found
@@ -95,19 +95,25 @@ def main():
                 print("No candidates found\n\n")
     else:
         print(f"Searching the Portage File List for packages installing {cmd}...\n")
-        try:
-            options = {
-                'file': cmd
-            }
-            ret, out = pfl.e_file.run(options)
-            if ret == 0:
-                found = True
-                sys.stdout.write(out)
-                print("")
-        except SystemExit:
-            # If something is not working just quit
-            print("No candidates found\n\n")    
-
+        found = False
+        for path in paths:
+            x = path + "/" + cmd
+            try:
+                options = {
+                    'file': x
+                }
+                ret, out = pfl.e_file.run(options)
+            except SystemExit:
+                # If something is not working just quit
+                break
+            else:
+                if ret == 0:
+                    found = True
+                    sys.stdout.write(out)
+        if found:
+            print("")
+        else:
+            print("No candidates found\n\n")
 
 if __name__ == "__main__":
     main()

--- a/command-not-found
+++ b/command-not-found
@@ -66,9 +66,10 @@ def main():
             "/usr/sbin",
             "/opt/bin"
         ]
+
     try:
         # Trying using e_file as module directly
-        import e_file.e_file
+        import pfl.e_file
     except ModuleNotFoundError:
         # If that doesn't work call it via subprocess instead
         e_file = "/usr/bin/e-file"
@@ -94,23 +95,18 @@ def main():
                 print("No candidates found\n\n")
     else:
         print(f"Searching the Portage File List for packages installing {cmd}...\n")
-        found = False
-        for path in paths:
-            x = path + "/" + cmd
-            try:
-                ret, out = e_file.e_file.run([x])
-            except SystemExit:
-                # If something is not working just quit
-                break
-            else:
-                if ret == 0:
-                    found = True
-                    sys.stdout.write(out)
-
-        if found:
-            print("")
-        else:
-            print("No candidates found\n\n")
+        try:
+            options = {
+                'file': cmd
+            }
+            ret, out = pfl.e_file.run(options)
+            if ret == 0:
+                found = True
+                sys.stdout.write(out)
+                print("")
+        except SystemExit:
+            # If something is not working just quit
+            print("No candidates found\n\n")    
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR does now reflect the current develop changes made with https://github.com/portagefilelist/client/commit/037d214c48d8446b47d8e707fbb30be04800aea4 There I've changed the modules to be more module-like and not a patched up version of something summed up over the years.

The changes to **command-not-found** are minimal. Renamed to the new imports and removed the loop around calling pfl. Pfl does a good job already by searching for a command and will return multiple results. There is no need to do multiple calls to pfl. Does make it faster, too.