### PR TITLE
Gracefully exit on keyboard interrupt

### DIFF
--- a/command-not-found
+++ b/command-not-found
@@ -136,4 +136,9 @@ def main():
             print("No candidates found\n\n")
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt as e:
+        pass
+
+        


### PR DESCRIPTION
A lot of the time, I spam ctrl c when I realize I type a command wrong. Unfortunately, that usually ends up leaving my terminal like this:
![image](https://github.com/user-attachments/assets/5ad8a5cd-0892-444a-9da2-722bbd999b36)
This pr just makes it fail much more gracefully:
![image](https://github.com/user-attachments/assets/8696214e-8917-4211-bbaa-e94a612059d2)
